### PR TITLE
Made it dynamic so any keychron that should work, can.

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This script scans your USB tree for any device containing the name "Keychron", e
 
 1. Ensure all your Keychron keyboards are connected via USB (Wired mode).
 2. Run the script:
-```Bash/Zsh
+```Zsh
 ./setup_keychron_webhid.sh
 ```
 4. Once the script finishes, **unplug and replug** your keyboards.

--- a/README.md
+++ b/README.md
@@ -25,7 +25,9 @@ Before running the hardware configuration, you must enable WebHID support in you
 2. Navigate to: chrome://flags/#enable-experimental-web-platform-features
 3. Set **Experimental Web Platform features** to **Enabled**.
 4. Click **Relaunch** at the bottom of the browser.
-
+> Yeah, I didn't do that because I forgot but it worked fine. I used Ungoogled Chromium.‎ ‎ ‎ ‎ ‎ ‎ ‎
+###### LeeLupton
+---
 ## 2. Usage
 
 This script scans your USB tree for any device containing the name "Keychron", extracts its unique Vendor ID (VID) and Product ID (PID), and automatically generates the necessary udev rules.

--- a/README.md
+++ b/README.md
@@ -1,41 +1,48 @@
-[https://www.gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0)
- # Fix WebHID connection for Keychron Q5 HE on Arch Linux (Chromium)
+# Keychron WebHID Enabler for Arch Linux
 
-This is a minimal, step-by-step guide for the exact fix that worked.
+---
 
-Notes:
-- Verified on Arch Linux (Omnarchy) with Chromium.
-- Keyboard model: Keychron Q5 HE (USB IDs: `3434:0b50`).
-- Replace IDs if your device differs (run `lsusb` to check).
+![Bash](https://img.shields.io/badge/Bash-5.x-4EAA25?logo=gnubash&logoColor=white)
+![Arch Linux](https://img.shields.io/badge/Arch_Linux-1793D1?logo=archlinux&logoColor=white)
+![udev](https://img.shields.io/badge/udev-rules-555555?logo=linux&logoColor=white)
+![WebHID](https://img.shields.io/badge/WebHID-API-4285F4?logo=googlechrome&logoColor=white)
+![Chromium](https://img.shields.io/badge/Chromium-native-0F70E0?logo=googlechrome&logoColor=white)
+![QMK](https://img.shields.io/badge/QMK-compatible-blue?logo=qmk&logoColor=white)
+![VIA](https://img.shields.io/badge/VIA-compatible-9B59B6)
+[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
-## 1) Enable Web Platform features in Chromium
-- Go to: `chrome://flags/#enable-experimental-web-platform-features`
-- Set to: Enabled
-- Relaunch Chromium
+---
 
-## 2) Add udev rules for the Q5 HE
-Create a rules file with your device’s vendor/product IDs (this guide uses Q5 HE: `3434:0b50`):
+This repository provides an automated script to enable WebHID support for multiple Keychron keyboards (QMK/VIA/Launcher compatible) on Arch Linux.
 
-```bash
-sudo tee /etc/udev/rules.d/50-keychron-q5-he.rules >/dev/null <<'EOF'
-# Keychron Q5 HE (WebHID)
-KERNEL=="hidraw*", SUBSYSTEM=="hidraw", ATTRS{idVendor}=="3434", ATTRS{idProduct}=="0b50", MODE="0666", TAG+="uaccess", TAG+="udev-acl"
-EOF
-```
+By default, Linux restricts user access to raw USB/HID interfaces. Because the [Keychron Launcher](https://launcher.keychron.com/) operates via the browser using the WebHID API, you must explicitly grant it permission to read and write to your keyboards' firmware.
 
-Apply the rules and replug:
+## 1. Prerequisites
 
-```bash
-sudo udevadm control --reload-rules
-sudo udevadm trigger
-# Unplug and replug the keyboard USB cable
-```
+Before running the hardware configuration, you must enable WebHID support in your Chromium-based browser.
 
-## 3) Connect in the Keychron web tool
-- Use Chromium (not Firefox).
-- Keyboard in wired USB mode.
-- Open the Keychron web configurator/launcher, click Connect, select the device.
+1. Open Chromium (ensure it is a native package, not a Flatpak/Snap, as sandboxing blocks raw USB access).
+2. Navigate to: chrome://flags/#enable-experimental-web-platform-features
+3. Set **Experimental Web Platform features** to **Enabled**.
+4. Click **Relaunch** at the bottom of the browser.
 
-If your model is different:
-- Find IDs with `lsusb` (format `vvvv:pppp`).
-- Replace `3434` (vendor) and `0b50` (product) in the udev rule accordingly.
+## 2. Usage
+
+This script scans your USB tree for any device containing the name "Keychron", extracts its unique Vendor ID (VID) and Product ID (PID), and automatically generates the necessary udev rules.
+
+1. Ensure all your Keychron keyboards are connected via USB (Wired mode).
+2. Run the script:
+./setup_keychron_webhid.sh
+3. Once the script finishes, **unplug and replug** your keyboards.
+
+## 3. Connect via Keychron Launcher
+
+1. Go to the [Keychron Launcher](https://launcher.keychron.com/) in Chromium.
+2. Click **Connect**.
+3. A browser prompt will appear showing your available Keychron devices. Select the one you want to configure and click **Connect**.
+
+## Troubleshooting
+
+* **Browser Cannot See Devices:** Double-check that you are not using a Flatpak version of Chromium/Brave. Flatpaks isolate the browser from the host's hardware interfaces. Use sudo pacman -S chromium to install the native version.
+* **"Device In Use" Error:** Close any standalone VIA desktop applications, QMK toolboxes, or other browser tabs that might already have an active lock on the keyboard's HID interface.
+* **No Devices Found by Script:** Ensure the physical toggle switch on the back of the keyboards is set to **Cable** and that you are using data-capable USB cables.

--- a/README.md
+++ b/README.md
@@ -32,8 +32,10 @@ This script scans your USB tree for any device containing the name "Keychron", e
 
 1. Ensure all your Keychron keyboards are connected via USB (Wired mode).
 2. Run the script:
-```./setup_keychron_webhid.sh```
-3. Once the script finishes, **unplug and replug** your keyboards.
+```Bash/Zsh
+./setup_keychron_webhid.sh
+```
+4. Once the script finishes, **unplug and replug** your keyboards.
 
 ## 3. Connect via Keychron Launcher
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-# Fix WebHID connection for Keychron Q5 HE on Arch Linux (Chromium)
+ []([https://www.gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0))
+ # Fix WebHID connection for Keychron Q5 HE on Arch Linux (Chromium)
 
 This is a minimal, step-by-step guide for the exact fix that worked.
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This script scans your USB tree for any device containing the name "Keychron", e
 
 1. Ensure all your Keychron keyboards are connected via USB (Wired mode).
 2. Run the script:
-./setup_keychron_webhid.sh
+```./setup_keychron_webhid.sh```
 3. Once the script finishes, **unplug and replug** your keyboards.
 
 ## 3. Connect via Keychron Launcher

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
- []([https://www.gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0))
+[https://www.gnu.org/licenses/gpl-3.0](https://www.gnu.org/licenses/gpl-3.0)
  # Fix WebHID connection for Keychron Q5 HE on Arch Linux (Chromium)
 
 This is a minimal, step-by-step guide for the exact fix that worked.

--- a/README.md
+++ b/README.md
@@ -9,7 +9,6 @@
 ![Chromium](https://img.shields.io/badge/Chromium-native-0F70E0?logo=googlechrome&logoColor=white)
 ![QMK](https://img.shields.io/badge/QMK-compatible-blue?logo=qmk&logoColor=white)
 ![VIA](https://img.shields.io/badge/VIA-compatible-9B59B6)
-[![License: GPL v3](https://img.shields.io/badge/License-GPLv3-blue.svg)](https://www.gnu.org/licenses/gpl-3.0)
 
 ---
 

--- a/setup_keychron_webhid.sh
+++ b/setup_keychron_webhid.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+echo "Scanning for Keychron devices..."
+# Find all Keychron devices using lsusb
+devices=$(lsusb | grep -i "keychron")
+
+if [ -z "$devices" ]; then
+    echo "Error: No Keychron devices found. Please ensure they are plugged in via USB cable."
+    exit 1
+fi
+
+echo "Found the following devices:"
+echo "$devices"
+echo "----------------------------------------"
+
+# Loop through each detected device
+while read -r line; do
+    # Extract the VID:PID pair (Field 6 in standard lsusb output)
+    id_pair=$(echo "$line" | awk '{print $6}')
+    vid=$(echo "$id_pair" | cut -d':' -f1)
+    pid=$(echo "$id_pair" | cut -d':' -f2)
+    
+    # Define a dynamic file name based on the IDs to prevent overwriting
+    rule_file="/etc/udev/rules.d/50-keychron-${vid}-${pid}.rules"
+    
+    echo "Configuring WebHID access for Device ID: $vid:$pid"
+    
+    # Generate the udev rule content
+    rule_content="# Dynamically generated WebHID rule for Keychron ($vid:$pid)
+KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", ATTRS{idVendor}==\"$vid\", ATTRS{idProduct}==\"$pid\", MODE=\"0666\", TAG+=\"uaccess\", TAG+=\"udev-acl\""
+    
+    # Write the rule to the system directory
+    echo "$rule_content" | sudo tee "$rule_file" > /dev/null
+    echo "Created rule file: $rule_file"
+
+done <<< "$devices"
+
+echo "----------------------------------------"
+echo "Reloading udev rules..."
+sudo udevadm control --reload-rules
+sudo udevadm trigger
+
+echo "Setup complete! Please UNPLUG and REPLUG all Keychron keyboards to apply the new permissions."

--- a/setup_keychron_webhid.sh
+++ b/setup_keychron_webhid.sh
@@ -25,9 +25,10 @@ while read -r line; do
     
     echo "Configuring WebHID access for Device ID: $vid:$pid"
     
-    # Generate the udev rule content
+    #### Shoutout to @StefanMarAntonsson for this code ####
     rule_content="# Dynamically generated WebHID rule for Keychron ($vid:$pid)
 KERNEL==\"hidraw*\", SUBSYSTEM==\"hidraw\", ATTRS{idVendor}==\"$vid\", ATTRS{idProduct}==\"$pid\", MODE=\"0666\", TAG+=\"uaccess\", TAG+=\"udev-acl\""
+    #### -------------------------------------------- ####
     
     # Write the rule to the system directory
     echo "$rule_content" | sudo tee "$rule_file" > /dev/null


### PR DESCRIPTION
Tested with k3 and q10 max southpaw. Both worked perfectly. Thanks for the solution. Hopefully this helps more people use it! 
- Added a **shell script** that dynamically applies the device data to the initial script from the README. *Worked on both keychron boards that I have first try each time*. 
- Added badges to the README.md so people aren't trying to figure out if its for them.
- Credited original code in the script.
- **Claude rewrote README.md**. If you don't like something in it lmk. 

First pull request!